### PR TITLE
Update order of virtual servers

### DIFF
--- a/swagger-v2/swagger.yaml
+++ b/swagger-v2/swagger.yaml
@@ -12,12 +12,12 @@ info:
 servers:
 - url: https://virtserver.swaggerhub.com/GoCartPay/gocart-payment-request-api/2.0.0
   description: SwaggerHub API Auto Mocking
-- url: https://virtserver.swaggerhub.com/GoCartPay/gocart-payments-api/2.0.0
-  description: SwaggerHub API Auto Mocking
 - url: https://api-staging.gocartpay.com/v2
   description: GoCart Staging Environment
 - url: https://api.gocartpay.com/v2
   description: GoCart Production Environment
+- url: https://virtserver.swaggerhub.com/GoCartPay/gocart-payments-api/2.0.0
+  description: SwaggerHub API Auto Mocking
 tags:
 - name: Payment Requests
   description: |


### PR DESCRIPTION
There is an extra server (other APIs have 3; this one has 4) that was being displayed in the API Reference page for these endpoints. Changed the order of the servers to display the correct API reference endpoint.